### PR TITLE
Quantization and extra args

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ variables:
 | SERVED_MODEL_NAME  | OPTIONAL, The model name used in the API. If not specified, the model name will be the same as the huggingface name. |
 | GPU_MEMORY_UTILIZATION | OPTIONAL, the max memory allowed to be utilized, default is 0.85     |
 | PORT | OPTIONAL, the port to use for serving, default is 8080     |
+| QUANTIZATION | OPTIONAL, the quantization method. Choices: 'awq', 'squeezellm' |
+| EXTRA_ARGS | OPTIONAL, Any additional command line arguments to pass along |
 
 
 The container image automatically detects the number of GPUs and sets

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,12 @@ fi
 
 additional_args=${EXTRA_ARGS:-""}
 if [[ ! -z "${QUANTIZATION}" ]]; then
-    additional_args="${additional_args} -q ${QUANTIZATION}"
+    if [[ -z "${DTYPE}" ]]; then
+        echo "Missing required environment variable DTYPE when QUANTIZATION is set"
+        exit 1
+    else
+        additional_args="${additional_args} -q ${QUANTIZATION} --dtype ${DTYPE}"
+    fi
 fi
 
 python3 -m vllm.entrypoints.openai.api_server \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,14 @@ if [[ ! -z "${QUANTIZATION}" ]]; then
     fi
 fi
 
+if [[ ! -z "${GPU_MEMORY_UTILIZATION}" ]]; then
+    additional_args="${additional_args} --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION}"
+fi
+
+if [[ ! -z "${MAX_MODEL_LEN}" ]]; then
+    additional_args="${additional_args} --max-model-len ${MAX_MODEL_LEN}"
+fi
+
 python3 -m vllm.entrypoints.openai.api_server \
     --tensor-parallel-size ${NUM_GPU} \
     --worker-use-ray \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,22 +10,9 @@ if [[ -z "${MODEL}" ]]; then
     exit 1
 fi
 
-if ${QUANTIZATION}; then
-    if [[ -z "${DTYPE}" ]]; then
-        echo "Missing required environment variable DTYPE"
-        exit 1
-    else
-        python3 -m vllm.entrypoints.openai.api_server \
-            --tensor-parallel-size ${NUM_GPU} \
-            --worker-use-ray \
-            --host 0.0.0.0 \
-            --port "${PORT}" \
-            --model "${MODEL}" \
-            --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
-            --served-model-name "${SERVED_MODEL_NAME}" \
-            --quantization "${QUANTIZATION}" \
-            --dtype "${DTYPE}"
-    fi
+additional_args=${EXTRA_ARGS:-""}
+if [[ ! -z "${QUANTIZATION}" ]]; then
+    additional_args="${additional_args} -q ${QUANTIZATION}"
 fi
 
 python3 -m vllm.entrypoints.openai.api_server \
@@ -35,4 +22,4 @@ python3 -m vllm.entrypoints.openai.api_server \
     --port "${PORT}" \
     --model "${MODEL}" \
     --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
-    --served-model-name "${SERVED_MODEL_NAME}"
+    --served-model-name "${SERVED_MODEL_NAME}" ${additional_args}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,24 @@ if [[ -z "${MODEL}" ]]; then
     exit 1
 fi
 
+if ${QUANTIZATION}; then
+    if [[ -z "${DTYPE}" ]]; then
+        echo "Missing required environment variable DTYPE"
+        exit 1
+    else
+        python3 -m vllm.entrypoints.openai.api_server \
+            --tensor-parallel-size ${NUM_GPU} \
+            --worker-use-ray \
+            --host 0.0.0.0 \
+            --port "${PORT}" \
+            --model "${MODEL}" \
+            --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+            --served-model-name "${SERVED_MODEL_NAME}" \
+            --quantization "${QUANTIZATION}" \
+            --dtype "${DTYPE}"
+    fi
+fi
+
 python3 -m vllm.entrypoints.openai.api_server \
     --tensor-parallel-size ${NUM_GPU} \
     --worker-use-ray \


### PR DESCRIPTION
Thanks to @DylanAlloy for original PR

Image ID you can use for testing: `ghcr.io/substratusai/vllm:pr-5`

Testing it out in K8s

Helm install:
```
helm repo add substratusai https://substratusai.github.io/helm
# Note by default the resource limit is set to 1 GPU
helm upgrade --install mistral-7b-awq substratusai/vllm  -f - << EOF
model: TheBloke/Mistral-7B-Instruct-v0.1-AWQ
image:
  tag: pr-5
env:
- name: QUANTIZATION
  value: awq
- name: DTYPE
  value: half
EOF
```